### PR TITLE
Add `tosa_linalg` pipeline that lowers to `tosa` prior to `linalg_on_tensors` ops

### DIFF
--- a/include/torch-mlir/Conversion/Passes.td
+++ b/include/torch-mlir/Conversion/Passes.td
@@ -121,11 +121,14 @@ def ConvertTorchToTosa : Pass<"convert-torch-to-tosa", "func::FuncOp"> {
     guards in case of shape mismatches.
   }];
   let constructor = "mlir::torch::createConvertTorchToTosaPass()";
-  // Specify any options.
-  let options = [
-    Option<"bypassIllegalOpsCheck", "bypass-illegal-ops-check", "bool", /*default=*/"false",
-           "Bypass the checks for illegal ops during pattern rewrite">,
-  ];
+}
+
+def ConvertTorchToTosaLinalg : Pass<"convert-torch-to-tosa-linalg", "func::FuncOp"> {
+  let summary = "Convert Torch ops to a mix of TOSA ops and LINALG_ON_TENSORS ops";
+  let description = [{
+    This pass tries to lower torch ops to tosa ops if possible. Otherwise lowers to a mix of linalg, tensor, scf, and other dialects.
+  }];
+  let constructor = "mlir::torch::createConvertTorchToTosaLinalgPass()";
 }
 
 def ConvertTorchToTMTensor : Pass<"convert-torch-to-tmtensor", "func::FuncOp"> {

--- a/include/torch-mlir/Conversion/Passes.td
+++ b/include/torch-mlir/Conversion/Passes.td
@@ -121,6 +121,11 @@ def ConvertTorchToTosa : Pass<"convert-torch-to-tosa", "func::FuncOp"> {
     guards in case of shape mismatches.
   }];
   let constructor = "mlir::torch::createConvertTorchToTosaPass()";
+  // Specify any options.
+  let options = [
+    Option<"bypassIllegalOpsCheck", "bypass-illegal-ops-check", "bool", /*default=*/"false",
+           "Bypass the checks for illegal ops during pattern rewrite">,
+  ];
 }
 
 def ConvertTorchToTMTensor : Pass<"convert-torch-to-tmtensor", "func::FuncOp"> {

--- a/include/torch-mlir/Conversion/TorchToLinalg/TorchToLinalg.h
+++ b/include/torch-mlir/Conversion/TorchToLinalg/TorchToLinalg.h
@@ -17,9 +17,9 @@
 
 namespace mlir {
 namespace torch {
-void populateTorchToLinalgOnTensorsPatternsAndLegality(
-    TypeConverter &typeConverter, RewritePatternSet &patterns,
-    ConversionTarget &target);
+void populateTorchToLinalgOnTensorsPatterns(TypeConverter &typeConverter,
+                                            RewritePatternSet &patterns);
+void populateTorchToLinalgOnTensorsOpsLegality(ConversionTarget &target);
 std::unique_ptr<OperationPass<func::FuncOp>> createConvertTorchToLinalgPass();
 } // namespace torch
 } // namespace mlir

--- a/include/torch-mlir/Conversion/TorchToTosa/TorchToTosa.h
+++ b/include/torch-mlir/Conversion/TorchToTosa/TorchToTosa.h
@@ -18,6 +18,11 @@
 namespace mlir {
 namespace torch {
 
+/// Collect a set of legal/illegal ops for converting Torch operations to Tosa
+/// dialect.
+void populateTorchToTosaConversionLegalOps(ConversionTarget &target);
+void populateTorchToTosaConversionIllegalOps(ConversionTarget &target);
+
 /// Collect a set of patterns to convert Torch operations to Tosa dialect.
 void populateTorchToTosaConversionPatterns(TypeConverter &typeConverter,
                                            RewritePatternSet &patterns);

--- a/include/torch-mlir/Conversion/TorchToTosa/TorchToTosa.h
+++ b/include/torch-mlir/Conversion/TorchToTosa/TorchToTosa.h
@@ -12,13 +12,17 @@
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
 #include <memory>
 
 namespace mlir {
 namespace torch {
+
+/// Collect a set of patterns to convert Torch operations to Tosa dialect.
+void populateTorchToTosaConversionPatterns(TypeConverter &typeConverter,
+                                           RewritePatternSet &patterns);
+
 std::unique_ptr<OperationPass<func::FuncOp>> createConvertTorchToTosaPass();
-std::unique_ptr<OperationPass<func::FuncOp>>
-createConvertTorchToTosaPass(bool bypassIllegalOpsCheck);
 } // namespace torch
 } // namespace mlir
 

--- a/include/torch-mlir/Conversion/TorchToTosa/TorchToTosa.h
+++ b/include/torch-mlir/Conversion/TorchToTosa/TorchToTosa.h
@@ -17,7 +17,9 @@
 namespace mlir {
 namespace torch {
 std::unique_ptr<OperationPass<func::FuncOp>> createConvertTorchToTosaPass();
-}
+std::unique_ptr<OperationPass<func::FuncOp>>
+createConvertTorchToTosaPass(bool bypassIllegalOpsCheck);
+} // namespace torch
 } // namespace mlir
 
 #endif // TORCHMLIR_CONVERSION_TORCHTOTOSA_TORCHTOTOSA_H

--- a/include/torch-mlir/Conversion/TorchToTosaLinalg/TorchToTosaLinalg.h
+++ b/include/torch-mlir/Conversion/TorchToTosaLinalg/TorchToTosaLinalg.h
@@ -7,21 +7,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef TORCHMLIR_CONVERSION_ATENTOLINALG_ATENTOLINALG_H
-#define TORCHMLIR_CONVERSION_ATENTOLINALG_ATENTOLINALG_H
+#ifndef TORCHMLIR_CONVERSION_ATENTOTOSALINALG_ATENTOTOSALINALG_H
+#define TORCHMLIR_CONVERSION_ATENTOTOSALINALG_ATENTOTOSALINALG_H
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
-#include "mlir/Transforms/DialectConversion.h"
 #include <memory>
 
 namespace mlir {
 namespace torch {
-void populateTorchToLinalgOnTensorsPatternsAndLegality(
-    TypeConverter &typeConverter, RewritePatternSet &patterns,
-    ConversionTarget &target);
-std::unique_ptr<OperationPass<func::FuncOp>> createConvertTorchToLinalgPass();
-} // namespace torch
+std::unique_ptr<OperationPass<func::FuncOp>>
+createConvertTorchToTosaLinalgPass();
+}
 } // namespace mlir
 
-#endif // TORCHMLIR_CONVERSION_ATENTOLINALG_ATENTOLINALG_H
+#endif // TORCHMLIR_CONVERSION_ATENTOTOSALINALG_ATENTOTOSALINALG_H

--- a/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.h
+++ b/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.h
@@ -30,6 +30,19 @@ void createTorchBackendToLinalgOnTensorsBackendPipeline(OpPassManager &pm);
 /// TOSA backend contract.
 void createTorchBackendToTosaBackendPipeline(OpPassManager &pm);
 
+/// Creates a pipeline that lowers from the torch backend contract to the
+/// TOSA + linalg backend contract.
+void createTorchBackendToTosaLinalgBackendPipeline(OpPassManager &pm);
+
+struct TosaBackendPipelineOptions
+    : public PassPipelineOptions<TosaBackendPipelineOptions> {
+  Option<bool> bypassIllegalOpsCheck{
+      *this, "bypass-illegal-ops-check",
+      llvm::cl::desc(
+          "Bypass the checks for illegal ops during pattern rewrite."),
+      llvm::cl::init(false)};
+};
+
 // Do not register the stablehlo options if the stablehlo target is disabled
 #ifdef TORCH_MLIR_ENABLE_STABLEHLO
 struct StablehloBackendPipelineOptions
@@ -78,6 +91,9 @@ std::unique_ptr<OperationPass<ModuleOp>>
 createVerifyLinalgOnTensorsBackendContractPass();
 
 std::unique_ptr<OperationPass<ModuleOp>> createVerifyTosaBackendContractPass();
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createVerifyTosaLinalgBackendContractPass();
 
 } // namespace TorchConversion
 

--- a/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.h
+++ b/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.h
@@ -34,15 +34,6 @@ void createTorchBackendToTosaBackendPipeline(OpPassManager &pm);
 /// TOSA + linalg backend contract.
 void createTorchBackendToTosaLinalgBackendPipeline(OpPassManager &pm);
 
-struct TosaBackendPipelineOptions
-    : public PassPipelineOptions<TosaBackendPipelineOptions> {
-  Option<bool> bypassIllegalOpsCheck{
-      *this, "bypass-illegal-ops-check",
-      llvm::cl::desc(
-          "Bypass the checks for illegal ops during pattern rewrite."),
-      llvm::cl::init(false)};
-};
-
 // Do not register the stablehlo options if the stablehlo target is disabled
 #ifdef TORCH_MLIR_ENABLE_STABLEHLO
 struct StablehloBackendPipelineOptions

--- a/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.td
+++ b/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.td
@@ -66,6 +66,11 @@ def VerifyTosaBackendContract : Pass<"torch-verify-tosa-backend-contract", "Modu
   let constructor = "mlir::torch::TorchConversion::createVerifyTosaBackendContractPass()";
 }
 
+def VerifyTosaLinalgBackendContract : Pass<"torch-verify-tosa-linalg-backend-contract", "ModuleOp"> {
+  let summary = "Verifies conformity to the tosa + linalg-on-tensors backend contract";
+  let constructor = "mlir::torch::TorchConversion::createVerifyTosaLinalgBackendContractPass()";
+}
+
 #ifdef TORCH_MLIR_ENABLE_STABLEHLO
 def VerifyStablehloBackendContract : Pass<"torch-verify-stablehlo-backend-contract", "ModuleOp"> {
   let summary = "Verifies conformity to the stablehlo backend contract";

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -4,6 +4,7 @@ add_subdirectory(TorchToLinalg)
 add_subdirectory(TorchToSCF)
 add_subdirectory(TorchToTensor)
 add_subdirectory(TorchToTosa)
+add_subdirectory(TorchToTosaLinalg)
 if(TORCH_MLIR_ENABLE_STABLEHLO)
   add_subdirectory(TorchToStablehlo)
 endif()
@@ -17,6 +18,7 @@ set(linked_libs TorchMLIRTorchToArith
                 TorchMLIRTorchToSCF
                 TorchMLIRTorchToTensor
                 TorchMLIRTorchToTosa
+                TorchMLIRTorchToTosaLinalg
                 TorchMLIRTorchToTMTensor
                 TorchMLIRTorchConversionToMLProgram
                 TorchMLIRConversionUtils)

--- a/lib/Conversion/Passes.cpp
+++ b/lib/Conversion/Passes.cpp
@@ -20,6 +20,7 @@
 #include "torch-mlir/Conversion/TorchToTMTensor/TorchToTMTensor.h"
 #include "torch-mlir/Conversion/TorchToTensor/TorchToTensor.h"
 #include "torch-mlir/Conversion/TorchToTosa/TorchToTosa.h"
+#include "torch-mlir/Conversion/TorchToTosaLinalg/TorchToTosaLinalg.h"
 
 //===----------------------------------------------------------------------===//
 // Pass registration

--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -2611,21 +2611,43 @@ SmallVector<StringRef> ConvertSparseOperatorOp::legalizedNames = {
 };
 } // namespace
 
-void mlir::torch::torch_to_linalg::populateDataMovementPatternsAndLegality(
-    TypeConverter &typeConverter, RewritePatternSet &patterns,
-    ConversionTarget &target) {
-  // Add some legal ops for torch-torch lowering.
+void mlir::torch::torch_to_linalg::populateDataMovementOpsLegality(
+    ConversionTarget &target) { // Add some legal ops for torch-torch lowering.
   target.addLegalOp<ConstantIntOp>();
+  target.addIllegalOp<AtenReflectionPad1dOp>();
+  target.addIllegalOp<AtenReflectionPad2dOp>();
+  target.addIllegalOp<AtenFlattenUsingIntsOp>();
+  target.addIllegalOp<AtenUnflattenIntOp>();
+  target.addIllegalOp<AtenViewOp>();
+  target.addIllegalOp<AtenSqueezeOp>();
+  target.addIllegalOp<AtenSqueezeDimOp>();
+  target.addIllegalOp<AtenUnsqueezeOp>();
+  target.addIllegalOp<AtenTransposeIntOp>();
+  target.addIllegalOp<AtenPermuteOp>();
+  target.addIllegalOp<AtenSliceTensorOp>();
+  target.addIllegalOp<AtenCatOp>();
+  target.addIllegalOp<AtenBroadcastToOp>();
+  target.addIllegalOp<AtenContiguousOp>();
+  target.addIllegalOp<AtenCopyOp>();
+  target.addIllegalOp<AtenSliceScatterOp>();
+  target.addIllegalOp<AtenViewAsComplexOp>();
+  target.addIllegalOp<AtenViewAsRealOp>();
+  target.addIllegalOp<AtenDiagonalOp>();
+  target.addIllegalOp<AtenDiagEmbedOp>();
+  target.addDynamicallyLegalOp<OperatorOp>([&](Torch::OperatorOp op) {
+    return !ConvertSparseOperatorOp::isSparsePrimitive(op.getNameAttr());
+  });
+}
+
+void mlir::torch::torch_to_linalg::populateDataMovementPatterns(
+    TypeConverter &typeConverter, RewritePatternSet &patterns) {
 
   MLIRContext *context = patterns.getContext();
-  target.addIllegalOp<AtenReflectionPad1dOp>();
+
   patterns.add<ConvertAtenReflectionPad1dOp>(typeConverter, context);
-  target.addIllegalOp<AtenReflectionPad2dOp>();
   patterns.add<ConvertAtenReflectionPad2dOp>(typeConverter, context);
-  target.addIllegalOp<AtenFlattenUsingIntsOp>();
   patterns.add<ConvertAtenFlattenUsingIntsOp>(typeConverter, context);
   patterns.add<ConvertAtenUnflattenIntOp>(typeConverter, context);
-  target.addIllegalOp<AtenUnflattenIntOp>();
 
   // View op sadness: In the future, we only want ConvertAtenViewOpStrict,
   // but this requires work upstream to fully generalize reshape handling.
@@ -2636,46 +2658,26 @@ void mlir::torch::torch_to_linalg::populateDataMovementPatternsAndLegality(
   // due to not statically switching between inferred and non-inferred view
   // cases. They are ordered by optimiality of the lowerings they generate
   // when they are able.
-  target.addIllegalOp<AtenViewOp>();
   patterns.add<ConvertAtenViewOp>(typeConverter, context, /*benefit=*/300);
   patterns.add<ConvertAtenViewOpStrict>(typeConverter, context,
                                         /*benefit=*/200);
   patterns.add<ConvertAtenViewOpToReshape>(typeConverter, context,
                                            /*benefit=*/100);
-
-  target.addIllegalOp<AtenSqueezeOp>();
   patterns.add<ConvertAtenSqueezeOp>(typeConverter, context);
-  target.addIllegalOp<AtenSqueezeDimOp>();
   patterns.add<ConvertAtenSqueezeDimOp>(typeConverter, context);
-  target.addIllegalOp<AtenUnsqueezeOp>();
   patterns.add<ConvertAtenUnsqueezeOp>(typeConverter, context);
-  target.addIllegalOp<AtenTransposeIntOp>();
   patterns.add<ConvertAtenTransposeIntOp>(typeConverter, context);
-  target.addIllegalOp<AtenPermuteOp>();
   patterns.add<ConvertAtenPermuteOp>(typeConverter, context);
-  target.addIllegalOp<AtenSliceTensorOp>();
   patterns.add<ConvertAtenSliceTensorOp>(typeConverter, context);
-  target.addIllegalOp<AtenCatOp>();
   patterns.add<ConvertAtenCatOp>(typeConverter, context);
-  target.addIllegalOp<AtenBroadcastToOp>();
   patterns.add<ConvertAtenBroadcastToOp>(typeConverter, context);
-  target.addIllegalOp<AtenContiguousOp>();
   patterns.add<ConvertAtenContiguousOp>(typeConverter, context);
-  target.addIllegalOp<AtenCopyOp>();
   patterns.add<ConvertAtenCopyOp>(typeConverter, context);
-  target.addIllegalOp<AtenSliceScatterOp>();
   patterns.add<ConvertAtenSliceScatterOp>(typeConverter, context);
-  target.addIllegalOp<AtenViewAsComplexOp>();
   patterns.add<ConvertAtenViewAsComplexOp>(typeConverter, context);
-  target.addIllegalOp<AtenViewAsRealOp>();
   patterns.add<ConvertAtenViewAsRealOp>(typeConverter, context);
-  target.addIllegalOp<AtenDiagonalOp>();
   patterns.add<ConvertAtenDiagonalOp>(typeConverter, context);
-  target.addIllegalOp<AtenDiagEmbedOp>();
   patterns.add<ConvertAtenDiagEmbedOp>(typeConverter, context);
   // Rewrite all special sparse conversions hidden as operators.
-  target.addDynamicallyLegalOp<OperatorOp>([&](Torch::OperatorOp op) {
-    return !ConvertSparseOperatorOp::isSparsePrimitive(op.getNameAttr());
-  });
   patterns.add<ConvertSparseOperatorOp>(typeConverter, context);
 }

--- a/lib/Conversion/TorchToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/DataMovement.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Matchers.h"
 #include "torch-mlir/Conversion/TorchToLinalg/Utils.h"
 #include "torch-mlir/Conversion/Utils/Utils.h"

--- a/lib/Conversion/TorchToLinalg/IndirectDataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/IndirectDataMovement.cpp
@@ -1104,23 +1104,25 @@ public:
 };
 } // namespace
 
-void mlir::torch::torch_to_linalg::
-    populateIndirectDataMovementPatternsAndLegality(
-        TypeConverter &typeConverter, RewritePatternSet &patterns,
-        ConversionTarget &target) {
-  MLIRContext *context = patterns.getContext();
+void mlir::torch::torch_to_linalg::populateIndirectDataMovementOpsLegality(
+    ConversionTarget &target) {
   target.addIllegalOp<AtenGatherOp>();
-  patterns.add<ConvertAtenGatherOp>(typeConverter, context);
   target.addIllegalOp<AtenEmbeddingOp>();
-  patterns.add<ConvertAtenEmbeddingOp>(typeConverter, context);
   target.addIllegalOp<AtenIndexSelectOp>();
-  patterns.add<ConvertAtenIndexSelectOp>(typeConverter, context);
   target.addIllegalOp<AtenIndexTensorHackedTwinOp>();
-  patterns.add<ConvertAtenIndexTensorHackedTwinOp>(typeConverter, context);
   target.addIllegalOp<AtenEmbeddingBagPaddingIdxOp>();
-  patterns.add<ConvertAtenEmbeddingBagPaddingIdxOp>(typeConverter, context);
   target.addIllegalOp<AtenUpsampleNearest2dOp>();
-  patterns.add<ConvertAtenUpsampleNearest2dOp>(typeConverter, context);
   target.addIllegalOp<AtenUpsampleNearest2dBackwardOp>();
+}
+
+void mlir::torch::torch_to_linalg::populateIndirectDataMovementPatterns(
+    TypeConverter &typeConverter, RewritePatternSet &patterns) {
+  MLIRContext *context = patterns.getContext();
+  patterns.add<ConvertAtenGatherOp>(typeConverter, context);
+  patterns.add<ConvertAtenEmbeddingOp>(typeConverter, context);
+  patterns.add<ConvertAtenIndexSelectOp>(typeConverter, context);
+  patterns.add<ConvertAtenIndexTensorHackedTwinOp>(typeConverter, context);
+  patterns.add<ConvertAtenEmbeddingBagPaddingIdxOp>(typeConverter, context);
+  patterns.add<ConvertAtenUpsampleNearest2dOp>(typeConverter, context);
   patterns.add<ConvertAtenUpsampleNearest2dBackwardOp>(typeConverter, context);
 }

--- a/lib/Conversion/TorchToLinalg/IndirectDataMovement.cpp
+++ b/lib/Conversion/TorchToLinalg/IndirectDataMovement.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Matchers.h"
 #include "torch-mlir/Conversion/TorchToLinalg/Utils.h"
 #include "torch-mlir/Conversion/Utils/Utils.h"

--- a/lib/Conversion/TorchToLinalg/Linear.cpp
+++ b/lib/Conversion/TorchToLinalg/Linear.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Matchers.h"
 #include "torch-mlir/Conversion/TorchToLinalg/Utils.h"
 #include "torch-mlir/Conversion/Utils/Utils.h"

--- a/lib/Conversion/TorchToLinalg/Linear.cpp
+++ b/lib/Conversion/TorchToLinalg/Linear.cpp
@@ -1387,18 +1387,21 @@ public:
 };
 } // namespace
 
-void mlir::torch::torch_to_linalg::populateLinearPatternsAndLegality(
-    TypeConverter &typeConverter, RewritePatternSet &patterns,
+void mlir::torch::torch_to_linalg::populateLinearOpsLegality(
     ConversionTarget &target) {
-  MLIRContext *context = patterns.getContext();
   target.addIllegalOp<AtenMmOp>();
-  patterns.add<ConvertAtenMmOp>(typeConverter, context);
   target.addIllegalOp<AtenFlipOp>();
-  patterns.add<ConvertAtenFlipOp>(typeConverter, context);
   target.addIllegalOp<AtenMatmulOp>();
-  patterns.add<ConvertAtenMatmulOp>(typeConverter, context);
   target.addIllegalOp<AtenBmmOp>();
-  patterns.add<ConvertAtenBmmOp>(typeConverter, context);
   target.addIllegalOp<AtenConvolutionOp>();
+}
+
+void mlir::torch::torch_to_linalg::populateLinearPatterns(
+    TypeConverter &typeConverter, RewritePatternSet &patterns) {
+  MLIRContext *context = patterns.getContext();
+  patterns.add<ConvertAtenMmOp>(typeConverter, context);
+  patterns.add<ConvertAtenFlipOp>(typeConverter, context);
+  patterns.add<ConvertAtenMatmulOp>(typeConverter, context);
+  patterns.add<ConvertAtenBmmOp>(typeConverter, context);
   patterns.add<ConvertAtenConvolutionOp>(typeConverter, context);
 }

--- a/lib/Conversion/TorchToLinalg/Pooling.cpp
+++ b/lib/Conversion/TorchToLinalg/Pooling.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Matchers.h"
 #include "torch-mlir/Conversion/TorchToLinalg/Utils.h"
 #include "torch-mlir/Conversion/Utils/Utils.h"

--- a/lib/Conversion/TorchToLinalg/Pooling.cpp
+++ b/lib/Conversion/TorchToLinalg/Pooling.cpp
@@ -1509,28 +1509,33 @@ public:
 };
 } // namespace
 
-void mlir::torch::torch_to_linalg::populatePoolingPatternsAndLegality(
-    TypeConverter &typeConverter, RewritePatternSet &patterns,
+void mlir::torch::torch_to_linalg::populatePoolingOpsLegality(
     ConversionTarget &target) {
-  MLIRContext *context = patterns.getContext();
+
   target.addIllegalOp<AtenMaxPool1dOp>();
   target.addIllegalOp<AtenMaxPool2dOp>();
   target.addIllegalOp<AtenMaxPool3dOp>();
+  target.addIllegalOp<AtenMaxPool2dWithIndicesOp>();
+  target.addIllegalOp<AtenMaxUnpool3dOp>();
+  target.addIllegalOp<AtenAvgPool1dOp, AtenAvgPool2dOp, AtenAvgPool3dOp>();
+  target.addIllegalOp<AtenAdaptiveAvgPool1dOp, AtenAdaptiveAvgPool2dOp,
+                      AtenAdaptiveAvgPool3dOp, Aten_AdaptiveAvgPool3dOp>();
+  target.addIllegalOp<AtenAdaptiveMaxPool1dOp, AtenAdaptiveMaxPool2dOp,
+                      AtenAdaptiveMaxPool3dOp, AtenMaxPool3dWithIndicesOp>();
+}
+
+void mlir::torch::torch_to_linalg::populatePoolingPatterns(
+    TypeConverter &typeConverter, RewritePatternSet &patterns) {
+  MLIRContext *context = patterns.getContext();
+
   patterns.add<ConvertAtenMaxPoolOp<AtenMaxPool1dOp>>(typeConverter, context);
   patterns.add<ConvertAtenMaxPoolOp<AtenMaxPool2dOp>>(typeConverter, context);
   patterns.add<ConvertAtenMaxPoolOp<AtenMaxPool3dOp>>(typeConverter, context);
-
-  target.addIllegalOp<AtenMaxPool2dWithIndicesOp>();
-  target.addIllegalOp<AtenMaxPool3dWithIndicesOp>();
   patterns.add<ConvertAtenMaxPoolOp<AtenMaxPool2dWithIndicesOp>>(typeConverter,
                                                                  context);
   patterns.add<ConvertAtenMaxPoolOp<AtenMaxPool3dWithIndicesOp>>(typeConverter,
                                                                  context);
-
-  target.addIllegalOp<AtenMaxUnpool3dOp>();
   patterns.add<ConvertAtenMaxUnpool3dOp>(typeConverter, context);
-
-  target.addIllegalOp<AtenAvgPool1dOp, AtenAvgPool2dOp, AtenAvgPool3dOp>();
   patterns
       .add<ConvertAtenAvgPoolOp<AtenAvgPool1dOp, linalg::PoolingNcwSumOp, 1>>(
           typeConverter, context);
@@ -1540,8 +1545,6 @@ void mlir::torch::torch_to_linalg::populatePoolingPatternsAndLegality(
   patterns
       .add<ConvertAtenAvgPoolOp<AtenAvgPool3dOp, linalg::PoolingNdhwcSumOp, 3>>(
           typeConverter, context);
-  target.addIllegalOp<AtenAdaptiveAvgPool1dOp, AtenAdaptiveAvgPool2dOp,
-                      AtenAdaptiveAvgPool3dOp, Aten_AdaptiveAvgPool3dOp>();
   patterns.add<ConvertAtenAdaptivePoolOp<AtenAdaptiveAvgPool1dOp>>(
       typeConverter, context);
   patterns.add<ConvertAtenAdaptivePoolOp<AtenAdaptiveAvgPool2dOp>>(
@@ -1550,8 +1553,6 @@ void mlir::torch::torch_to_linalg::populatePoolingPatternsAndLegality(
       typeConverter, context);
   patterns.add<ConvertAtenAdaptivePoolOp<Aten_AdaptiveAvgPool3dOp>>(
       typeConverter, context);
-  target.addIllegalOp<AtenAdaptiveMaxPool1dOp, AtenAdaptiveMaxPool2dOp,
-                      AtenAdaptiveMaxPool3dOp>();
   patterns.add<ConvertAtenAdaptivePoolOp<AtenAdaptiveMaxPool1dOp>>(
       typeConverter, context);
   patterns.add<ConvertAtenAdaptivePoolOp<AtenAdaptiveMaxPool2dOp>>(

--- a/lib/Conversion/TorchToLinalg/PopulatePatterns.h
+++ b/lib/Conversion/TorchToLinalg/PopulatePatterns.h
@@ -36,33 +36,33 @@ namespace torch_to_linalg {
 // lacks enough support for dynamic shapes and error assertions to be used
 // for this purpose.
 
-void populateTensorScalarInteropPatternsAndLegality(
-    TypeConverter &typeConverter, RewritePatternSet &patterns,
-    ConversionTarget &target);
-void populateLinearPatternsAndLegality(TypeConverter &typeConverter,
-                                       RewritePatternSet &patterns,
-                                       ConversionTarget &target);
-void populatePoolingPatternsAndLegality(TypeConverter &typeConverter,
-                                        RewritePatternSet &patterns,
-                                        ConversionTarget &target);
-void populateRandomPatternsAndLegality(TypeConverter &typeConverter,
-                                       RewritePatternSet &patterns,
-                                       ConversionTarget &target);
-void populateUncategorizedPatternsAndLegality(TypeConverter &typeConverter,
-                                              RewritePatternSet &patterns,
-                                              ConversionTarget &target);
-void populateReductionPatternsAndLegality(TypeConverter &typeConverter,
-                                          RewritePatternSet &patterns,
-                                          ConversionTarget &target);
-void populateDataMovementPatternsAndLegality(TypeConverter &typeConverter,
-                                             RewritePatternSet &patterns,
-                                             ConversionTarget &target);
-void populateIndirectDataMovementPatternsAndLegality(
-    TypeConverter &typeConverter, RewritePatternSet &patterns,
-    ConversionTarget &target);
-void populateTensorConstructorsPatternsAndLegality(TypeConverter &typeConverter,
-                                                   RewritePatternSet &patterns,
-                                                   ConversionTarget &target);
+void populateTensorScalarInteropPatterns(TypeConverter &typeConverter,
+                                         RewritePatternSet &patterns);
+void populateTensorScalarInteropOpsLegality(ConversionTarget &target);
+void populateLinearPatterns(TypeConverter &typeConverter,
+                            RewritePatternSet &patterns);
+void populateLinearOpsLegality(ConversionTarget &target);
+void populatePoolingPatterns(TypeConverter &typeConverter,
+                             RewritePatternSet &patterns);
+void populatePoolingOpsLegality(ConversionTarget &target);
+void populateRandomPatterns(TypeConverter &typeConverter,
+                            RewritePatternSet &patterns);
+void populateRandomOpsLegality(ConversionTarget &target);
+void populateUncategorizedPatterns(TypeConverter &typeConverter,
+                                   RewritePatternSet &patterns);
+void populateUncategorizedOpsLegality(ConversionTarget &target);
+void populateReductionPatterns(TypeConverter &typeConverter,
+                               RewritePatternSet &patterns);
+void populateReductionOpsLegality(ConversionTarget &target);
+void populateDataMovementPatterns(TypeConverter &typeConverter,
+                                  RewritePatternSet &patterns);
+void populateDataMovementOpsLegality(ConversionTarget &target);
+void populateIndirectDataMovementPatterns(TypeConverter &typeConverter,
+                                          RewritePatternSet &patterns);
+void populateIndirectDataMovementOpsLegality(ConversionTarget &target);
+void populateTensorConstructorsPatterns(TypeConverter &typeConverter,
+                                        RewritePatternSet &patterns);
+void populateTensorConstructorsOpsLegality(ConversionTarget &target);
 
 } // namespace torch_to_linalg
 } // namespace torch

--- a/lib/Conversion/TorchToLinalg/Random.cpp
+++ b/lib/Conversion/TorchToLinalg/Random.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Matchers.h"
 #include "torch-mlir/Conversion/TorchToLinalg/Utils.h"
 #include "torch-mlir/Conversion/Utils/Utils.h"

--- a/lib/Conversion/TorchToLinalg/Random.cpp
+++ b/lib/Conversion/TorchToLinalg/Random.cpp
@@ -517,14 +517,17 @@ public:
 };
 } // namespace
 
-void mlir::torch::torch_to_linalg::populateRandomPatternsAndLegality(
-    TypeConverter &typeConverter, RewritePatternSet &patterns,
+void mlir::torch::torch_to_linalg::populateRandomOpsLegality(
     ConversionTarget &target) {
-  MLIRContext *context = patterns.getContext();
   target.addIllegalOp<AtenDropoutOp>();
-  patterns.add<ConvertAtenDropoutOp>(typeConverter, context);
   target.addIllegalOp<AtenUniformOp>();
-  patterns.add<ConvertAtenUniformOp>(typeConverter, context);
   target.addIllegalOp<AtenMultinomialOp>();
+}
+
+void mlir::torch::torch_to_linalg::populateRandomPatterns(
+    TypeConverter &typeConverter, RewritePatternSet &patterns) {
+  MLIRContext *context = patterns.getContext();
+  patterns.add<ConvertAtenDropoutOp>(typeConverter, context);
+  patterns.add<ConvertAtenUniformOp>(typeConverter, context);
   patterns.add<ConvertAtenMultinomialOp>(typeConverter, context);
 }

--- a/lib/Conversion/TorchToLinalg/Reduction.cpp
+++ b/lib/Conversion/TorchToLinalg/Reduction.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Dialect/Complex/IR/Complex.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Matchers.h"
 #include "torch-mlir/Conversion/TorchToLinalg/Utils.h"
 #include "torch-mlir/Conversion/Utils/Utils.h"

--- a/lib/Conversion/TorchToLinalg/Reduction.cpp
+++ b/lib/Conversion/TorchToLinalg/Reduction.cpp
@@ -700,14 +700,8 @@ public:
 };
 } // namespace
 
-void mlir::torch::torch_to_linalg::populateReductionPatternsAndLegality(
-    TypeConverter &typeConverter, RewritePatternSet &patterns,
+void mlir::torch::torch_to_linalg::populateReductionOpsLegality(
     ConversionTarget &target) {
-  MLIRContext *context = patterns.getContext();
-  target.addIllegalOp<AtenMaxDimOp>();
-  patterns.add<ConvertAtenMinMaxDimOp<AtenMaxDimOp>>(typeConverter, context);
-  target.addIllegalOp<AtenMinDimOp>();
-  patterns.add<ConvertAtenMinMaxDimOp<AtenMinDimOp>>(typeConverter, context);
   target.addIllegalOp<AtenSumOp>();
   target.addIllegalOp<AtenAnyOp>();
   target.addIllegalOp<AtenAllOp>();
@@ -719,6 +713,12 @@ void mlir::torch::torch_to_linalg::populateReductionPatternsAndLegality(
   target.addIllegalOp<AtenAllDimOp>();
   target.addIllegalOp<AtenNormScalarOp>();
   target.addIllegalOp<AtenLinalgVectorNormOp>();
-  target.addIllegalOp<AtenFrobeniusNormDimOp>();
+}
+
+void mlir::torch::torch_to_linalg::populateReductionPatterns(
+    TypeConverter &typeConverter, RewritePatternSet &patterns) {
+  MLIRContext *context = patterns.getContext();
+  patterns.add<ConvertAtenMinMaxDimOp<AtenMaxDimOp>>(typeConverter, context);
+  patterns.add<ConvertAtenMinMaxDimOp<AtenMinDimOp>>(typeConverter, context);
   patterns.add<ConvertReductionOp>(typeConverter, context);
 }

--- a/lib/Conversion/TorchToLinalg/TensorConstructors.cpp
+++ b/lib/Conversion/TorchToLinalg/TensorConstructors.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Matchers.h"
 #include "torch-mlir/Conversion/TorchToLinalg/Utils.h"
 #include "torch-mlir/Conversion/Utils/Utils.h"

--- a/lib/Conversion/TorchToLinalg/TensorConstructors.cpp
+++ b/lib/Conversion/TorchToLinalg/TensorConstructors.cpp
@@ -615,22 +615,24 @@ public:
 };
 } // namespace
 
-void mlir::torch::torch_to_linalg::
-    populateTensorConstructorsPatternsAndLegality(TypeConverter &typeConverter,
-                                                  RewritePatternSet &patterns,
-                                                  ConversionTarget &target) {
-  MLIRContext *context = patterns.getContext();
+void mlir::torch::torch_to_linalg::populateTensorConstructorsOpsLegality(
+    ConversionTarget &target) {
   target.addIllegalOp<AtenReplicationPad2dOp>();
-  patterns.add<ConvertAtenReplicationPad2dOp>(typeConverter, context);
   target.addIllegalOp<AtenConstantPadNdOp>();
-  patterns.add<ConvertAtenConstantPadNdOp>(typeConverter, context);
   target.addIllegalOp<AtenZerosOp, AtenOnesOp>();
+  target.addIllegalOp<AtenEmptyMemoryFormatOp>();
+  target.addIllegalOp<AtenArangeStartStepOp>();
+}
+
+void mlir::torch::torch_to_linalg::populateTensorConstructorsPatterns(
+    TypeConverter &typeConverter, RewritePatternSet &patterns) {
+  MLIRContext *context = patterns.getContext();
+  patterns.add<ConvertAtenReplicationPad2dOp>(typeConverter, context);
+  patterns.add<ConvertAtenConstantPadNdOp>(typeConverter, context);
   patterns.add<ConvertConstantTensorAllocOp<AtenZerosOp, 0>>(typeConverter,
                                                              context);
   patterns.add<ConvertConstantTensorAllocOp<AtenOnesOp, 1>>(typeConverter,
                                                             context);
-  target.addIllegalOp<AtenEmptyMemoryFormatOp>();
   patterns.add<ConvertAtenEmptyMemoryFormatOp>(typeConverter, context);
   patterns.add<ConvertAtenArangeStartStepOp>(typeConverter, context);
-  target.addIllegalOp<AtenArangeStartStepOp>();
 }

--- a/lib/Conversion/TorchToLinalg/TensorScalarInterop.cpp
+++ b/lib/Conversion/TorchToLinalg/TensorScalarInterop.cpp
@@ -256,27 +256,32 @@ public:
 };
 } // namespace
 
-void mlir::torch::torch_to_linalg::
-    populateTensorScalarInteropPatternsAndLegality(TypeConverter &typeConverter,
-                                                   RewritePatternSet &patterns,
-                                                   ConversionTarget &target) {
-  MLIRContext *context = patterns.getContext();
+void mlir::torch::torch_to_linalg::populateTensorScalarInteropOpsLegality(
+    ConversionTarget &target) {
   target.addIllegalOp<AtenSizeIntOp>();
-  patterns.add<ConvertAtenSizeIntOp>(typeConverter, context);
   target.addIllegalOp<AtenNumelOp>();
-  patterns.add<ConvertAtenNumelOp>(typeConverter, context);
   target.addIllegalOp<AtenIntTensorOp, AtenFloatTensorOp, AtenBoolTensorOp>();
+  target.addIllegalOp<AtenTensorIntOp, AtenTensorFloatOp>();
+  target.addIllegalOp<PrimNumToTensorScalarOp>();
+  target.addIllegalOp<AtenFullOp>();
+  target.addIllegalOp<AtenScalarImplicitOp, AtenFloatImplicitOp,
+                      AtenIntImplicitOp>();
+}
+
+void mlir::torch::torch_to_linalg::populateTensorScalarInteropPatterns(
+    TypeConverter &typeConverter, RewritePatternSet &patterns) {
+  MLIRContext *context = patterns.getContext();
+  patterns.add<ConvertAtenSizeIntOp>(typeConverter, context);
+
+  patterns.add<ConvertAtenNumelOp>(typeConverter, context);
   patterns.add<ConvertAtenTensorToScalarLikeOp<AtenIntTensorOp>>(typeConverter,
                                                                  context);
   patterns.add<ConvertAtenTensorToScalarLikeOp<AtenFloatTensorOp>>(
       typeConverter, context);
   patterns.add<ConvertAtenTensorToScalarLikeOp<AtenBoolTensorOp>>(typeConverter,
                                                                   context);
-  target.addIllegalOp<AtenTensorIntOp, AtenTensorFloatOp>();
   patterns.add<ConvertAtenScalarToTensorLike>(typeConverter, context);
-  target.addIllegalOp<PrimNumToTensorScalarOp>();
   patterns.add<ConvertPrimNumToTensorScalarOp>(typeConverter, context);
-  target.addIllegalOp<AtenFullOp>();
   patterns.add<ConvertAtenFullOp>(typeConverter, context);
 
   patterns.add<ConvertAtenImplicitLikeOp<AtenScalarImplicitOp>>(typeConverter,
@@ -285,6 +290,4 @@ void mlir::torch::torch_to_linalg::
                                                                context);
   patterns.add<ConvertAtenImplicitLikeOp<AtenIntImplicitOp>>(typeConverter,
                                                              context);
-  target.addIllegalOp<AtenScalarImplicitOp, AtenFloatImplicitOp,
-                      AtenIntImplicitOp>();
 }

--- a/lib/Conversion/TorchToLinalg/TensorScalarInterop.cpp
+++ b/lib/Conversion/TorchToLinalg/TensorScalarInterop.cpp
@@ -12,6 +12,7 @@
 #include "PopulatePatterns.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "torch-mlir/Conversion/Utils/Utils.h"
 #include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
 #include "torch-mlir/Dialect/Torch/Utils/Utils.h"

--- a/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
+++ b/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
@@ -64,8 +64,8 @@ public:
 
     RewritePatternSet patterns(context);
 
-    torch::populateTorchToLinalgOnTensorsPatternsAndLegality(typeConverter,
-                                                             patterns, target);
+    torch::populateTorchToLinalgOnTensorsPatterns(typeConverter, patterns);
+    torch::populateTorchToLinalgOnTensorsOpsLegality(target);
 
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(patterns))))
@@ -75,27 +75,31 @@ public:
 } // namespace
 
 //  Add any new populate*PatternsAndLegality functionality here
-void mlir::torch::populateTorchToLinalgOnTensorsPatternsAndLegality(
-    TypeConverter &typeConverter, RewritePatternSet &patterns,
+void mlir::torch::populateTorchToLinalgOnTensorsPatterns(
+    TypeConverter &typeConverter, RewritePatternSet &patterns) {
+  torch_to_linalg::populateTensorScalarInteropPatterns(typeConverter, patterns);
+  torch_to_linalg::populateLinearPatterns(typeConverter, patterns);
+  torch_to_linalg::populatePoolingPatterns(typeConverter, patterns);
+  torch_to_linalg::populateRandomPatterns(typeConverter, patterns);
+  torch_to_linalg::populateUncategorizedPatterns(typeConverter, patterns);
+  torch_to_linalg::populateReductionPatterns(typeConverter, patterns);
+  torch_to_linalg::populateDataMovementPatterns(typeConverter, patterns);
+  torch_to_linalg::populateIndirectDataMovementPatterns(typeConverter,
+                                                        patterns);
+  torch_to_linalg::populateTensorConstructorsPatterns(typeConverter, patterns);
+}
+
+void mlir::torch::populateTorchToLinalgOnTensorsOpsLegality(
     ConversionTarget &target) {
-  torch_to_linalg::populateTensorScalarInteropPatternsAndLegality(
-      typeConverter, patterns, target);
-  torch_to_linalg::populateLinearPatternsAndLegality(typeConverter, patterns,
-                                                     target);
-  torch_to_linalg::populatePoolingPatternsAndLegality(typeConverter, patterns,
-                                                      target);
-  torch_to_linalg::populateRandomPatternsAndLegality(typeConverter, patterns,
-                                                     target);
-  torch_to_linalg::populateUncategorizedPatternsAndLegality(typeConverter,
-                                                            patterns, target);
-  torch_to_linalg::populateReductionPatternsAndLegality(typeConverter, patterns,
-                                                        target);
-  torch_to_linalg::populateDataMovementPatternsAndLegality(typeConverter,
-                                                           patterns, target);
-  torch_to_linalg::populateIndirectDataMovementPatternsAndLegality(
-      typeConverter, patterns, target);
-  torch_to_linalg::populateTensorConstructorsPatternsAndLegality(
-      typeConverter, patterns, target);
+  torch_to_linalg::populateTensorScalarInteropOpsLegality(target);
+  torch_to_linalg::populateLinearOpsLegality(target);
+  torch_to_linalg::populatePoolingOpsLegality(target);
+  torch_to_linalg::populateRandomOpsLegality(target);
+  torch_to_linalg::populateUncategorizedOpsLegality(target);
+  torch_to_linalg::populateReductionOpsLegality(target);
+  torch_to_linalg::populateDataMovementOpsLegality(target);
+  torch_to_linalg::populateIndirectDataMovementOpsLegality(target);
+  torch_to_linalg::populateTensorConstructorsOpsLegality(target);
 }
 
 std::unique_ptr<OperationPass<func::FuncOp>>

--- a/lib/Conversion/TorchToLinalg/Uncategorized.cpp
+++ b/lib/Conversion/TorchToLinalg/Uncategorized.cpp
@@ -3339,10 +3339,8 @@ public:
 };
 } // namespace
 
-void mlir::torch::torch_to_linalg::populateUncategorizedPatternsAndLegality(
-    TypeConverter &typeConverter, RewritePatternSet &patterns,
+void mlir::torch::torch_to_linalg::populateUncategorizedOpsLegality(
     ConversionTarget &target) {
-  MLIRContext *context = patterns.getContext();
   target.addIllegalOp<
       AtenTanOp, AtenTanhOp, AtenSinhOp, AtenCoshOp, AtenAtanhOp, AtenAcoshOp,
       AtenAsinOp, AtenAsinhOp, AtenReluOp, AtenGeluOp, AtenGeluBackwardOp,
@@ -3366,39 +3364,35 @@ void mlir::torch::torch_to_linalg::populateUncategorizedPatternsAndLegality(
       AtenTrilOp, AtenRemainderScalarOp, AtenRemainderTensorOp,
       AtenBitwiseNotOp, AtenRoundOp, AtenFillScalarOp, AtenFillTensorOp,
       AtenRealOp, AtenImagOp, AtenDequantizeSelfOp, AtenDequantizeTensorOp,
-      AtenQuantizePerTensorOp, AtenIscloseOp>();
+      AtenQuantizePerTensorOp, AtenIscloseOp, AtenNllLossForwardOp,
+      AtenDetachOp, AtenBatchNormOp, AtenLogitOp, PrimsCollapseOp,
+      PrimsSplitDimOp, AtenNllLossBackwardOp, TensorStaticInfoCastOp,
+      AtenIntReprOp, Aten_MakePerChannelQuantizedTensorOp,
+      Aten_MakePerTensorQuantizedTensorOp, AtenGridSamplerOp,
+      Aten__InterpolateSizeListScaleListOp, AtenLinalgDetOp, AtenPolarOp>();
+}
+
+void mlir::torch::torch_to_linalg::populateUncategorizedPatterns(
+    TypeConverter &typeConverter, RewritePatternSet &patterns) {
+  MLIRContext *context = patterns.getContext();
+
   patterns.add<ConvertElementwiseOp>(typeConverter, context);
-  target.addIllegalOp<AtenNllLossForwardOp>();
   patterns.add<ConvertAtenDetachOp>(typeConverter, context);
-  target.addIllegalOp<AtenDetachOp>();
   patterns.add<ConvertAtenNllLossForwardOp>(typeConverter, context);
-  target.addIllegalOp<AtenBatchNormOp>();
   patterns.add<ConvertAtenBatchNormOp>(typeConverter, context);
-  target.addIllegalOp<AtenLogitOp>();
   patterns.add<ConvertLogitOp>(typeConverter, context);
-  target.addIllegalOp<PrimsCollapseOp>();
   patterns.add<ConvertPrimsCollapseOp>(typeConverter, context);
-  target.addIllegalOp<PrimsSplitDimOp>();
   patterns.add<ConvertPrimsSplitDimOp>(typeConverter, context);
-  target.addIllegalOp<AtenNllLossBackwardOp>();
   patterns.add<ConvertAtenNllLossBackwardOp>(typeConverter, context);
   patterns.add<ConvertTensorStaticInfoCastOp>(typeConverter, context);
-  target.addIllegalOp<TensorStaticInfoCastOp>();
   patterns.add<ConvertAtenIntReprOp>(typeConverter, context);
-  target.addIllegalOp<AtenIntReprOp>();
   patterns.add<ConvertCastEquivalentOp<Aten_MakePerChannelQuantizedTensorOp>>(
       typeConverter, context);
-  target.addIllegalOp<Aten_MakePerChannelQuantizedTensorOp>();
   patterns.add<ConvertCastEquivalentOp<Aten_MakePerTensorQuantizedTensorOp>>(
       typeConverter, context);
-  target.addIllegalOp<Aten_MakePerTensorQuantizedTensorOp>();
   patterns.add<ConvertDequantizePerChannel>(typeConverter, context);
-  target.addIllegalOp<AtenGridSamplerOp>();
   patterns.add<ConvertAtenGridSamplerOp>(typeConverter, context);
-  target.addIllegalOp<Aten__InterpolateSizeListScaleListOp>();
   patterns.add<ConvertInterpolateOp>(typeConverter, context);
-  target.addIllegalOp<AtenLinalgDetOp>();
   patterns.add<ConvertAtenLinalgDetOp>(typeConverter, context);
-  target.addIllegalOp<AtenPolarOp>();
   patterns.add<ConvertAtenPolarOp>(typeConverter, context);
 }

--- a/lib/Conversion/TorchToLinalg/Uncategorized.cpp
+++ b/lib/Conversion/TorchToLinalg/Uncategorized.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Matchers.h"
 #include "torch-mlir/Conversion/TorchToLinalg/Utils.h"
 #include "torch-mlir/Conversion/Utils/Utils.h"

--- a/lib/Conversion/TorchToLinalg/Utils.cpp
+++ b/lib/Conversion/TorchToLinalg/Utils.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "torch-mlir/Conversion/TorchToLinalg/Utils.h"
 #include "torch-mlir/Conversion/Utils/Utils.h"
 #include "torch-mlir/Dialect/Torch/IR/TorchOps.h"

--- a/lib/Conversion/TorchToTosaLinalg/CMakeLists.txt
+++ b/lib/Conversion/TorchToTosaLinalg/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_mlir_conversion_library(TorchMLIRTorchToTosaLinalg
+  TorchToTosaLinalg.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/torch-mlir/Conversion/TorchToTosaLinalg
+
+  DEPENDS
+  TorchMLIRConversionPassIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRPass
+  MLIRTosaDialect
+  MLIRLinalgDialect
+  TorchMLIRConversionUtils
+  TorchMLIRTorchDialect
+)
+
+torch_mlir_target_includes(TorchMLIRTorchToTosaLinalg)

--- a/lib/Conversion/TorchToTosaLinalg/TorchToTosaLinalg.cpp
+++ b/lib/Conversion/TorchToTosaLinalg/TorchToTosaLinalg.cpp
@@ -7,10 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "torch-mlir/Conversion/TorchToTosaLinalg/TorchToTosaLinalg.h"
 #include "torch-mlir/Conversion/TorchToLinalg/TorchToLinalg.h"
+#include "torch-mlir/Conversion/TorchToTosa/TorchToTosa.h"
 
 #include "../PassDetail.h"
-#include "PopulatePatterns.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Complex/IR/Complex.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
@@ -19,6 +20,8 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchDialect.h"
 #include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"
 #include "torch-mlir/Dialect/TorchConversion/Transforms/BackendTypeConversion.h"
 
@@ -29,19 +32,17 @@ using namespace mlir::torch::Torch;
 // -----------------------------------------------------------------------------
 // The pass
 // -----------------------------------------------------------------------------
-// Patterns for individual ops should live in one of the other files, and
-// added via the relevant `populate*PatternsAndLegality` functions.
-// This file is just for the pass definition itself.
 
 namespace {
-class ConvertTorchToLinalg
-    : public ConvertTorchToLinalgBase<ConvertTorchToLinalg> {
+class ConvertTorchToTosaLinalg
+    : public ConvertTorchToTosaLinalgBase<ConvertTorchToTosaLinalg> {
 public:
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<linalg::LinalgDialect>();
     registry.insert<math::MathDialect>();
     registry.insert<func::FuncDialect>();
     registry.insert<tensor::TensorDialect>();
+    registry.insert<tosa::TosaDialect>();
     registry.insert<arith::ArithDialect>();
     registry.insert<cf::ControlFlowDialect>();
     registry.insert<scf::SCFDialect>();
@@ -52,11 +53,14 @@ public:
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     ConversionTarget target(*context);
-    target.addLegalDialect<
-        linalg::LinalgDialect, func::FuncDialect, cf::ControlFlowDialect,
-        math::MathDialect, scf::SCFDialect, sparse_tensor::SparseTensorDialect,
-        tensor::TensorDialect, arith::ArithDialect, complex::ComplexDialect>();
+    target.addLegalDialect<linalg::LinalgDialect, func::FuncDialect,
+                           cf::ControlFlowDialect, math::MathDialect,
+                           scf::SCFDialect, sparse_tensor::SparseTensorDialect,
+                           tosa::TosaDialect, tensor::TensorDialect,
+                           arith::ArithDialect, complex::ComplexDialect>();
     target.addLegalOp<TorchConversion::GetNextSeedOp>();
+
+    target.addIllegalDialect<Torch::TorchDialect>();
 
     TypeConverter typeConverter;
     typeConverter.addConversion([](Type type) { return type; });
@@ -64,6 +68,7 @@ public:
 
     RewritePatternSet patterns(context);
 
+    torch::populateTorchToTosaConversionPatterns(typeConverter, patterns);
     torch::populateTorchToLinalgOnTensorsPatternsAndLegality(typeConverter,
                                                              patterns, target);
 
@@ -74,31 +79,7 @@ public:
 };
 } // namespace
 
-//  Add any new populate*PatternsAndLegality functionality here
-void mlir::torch::populateTorchToLinalgOnTensorsPatternsAndLegality(
-    TypeConverter &typeConverter, RewritePatternSet &patterns,
-    ConversionTarget &target) {
-  torch_to_linalg::populateTensorScalarInteropPatternsAndLegality(
-      typeConverter, patterns, target);
-  torch_to_linalg::populateLinearPatternsAndLegality(typeConverter, patterns,
-                                                     target);
-  torch_to_linalg::populatePoolingPatternsAndLegality(typeConverter, patterns,
-                                                      target);
-  torch_to_linalg::populateRandomPatternsAndLegality(typeConverter, patterns,
-                                                     target);
-  torch_to_linalg::populateUncategorizedPatternsAndLegality(typeConverter,
-                                                            patterns, target);
-  torch_to_linalg::populateReductionPatternsAndLegality(typeConverter, patterns,
-                                                        target);
-  torch_to_linalg::populateDataMovementPatternsAndLegality(typeConverter,
-                                                           patterns, target);
-  torch_to_linalg::populateIndirectDataMovementPatternsAndLegality(
-      typeConverter, patterns, target);
-  torch_to_linalg::populateTensorConstructorsPatternsAndLegality(
-      typeConverter, patterns, target);
-}
-
 std::unique_ptr<OperationPass<func::FuncOp>>
-mlir::torch::createConvertTorchToLinalgPass() {
-  return std::make_unique<ConvertTorchToLinalg>();
+mlir::torch::createConvertTorchToTosaLinalgPass() {
+  return std::make_unique<ConvertTorchToTosaLinalg>();
 }

--- a/lib/Dialect/TorchConversion/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TorchConversion/Transforms/CMakeLists.txt
@@ -27,6 +27,7 @@ add_mlir_library(TorchMLIRTorchConversionPasses
   UnpackQuantTensor.cpp
   VerifyLinalgOnTensorsBackendContract.cpp
   VerifyTosaBackendContract.cpp
+  VerifyTosaLinalgBackendContract.cpp
   VerifyStablehloBackendContract.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Dialect/TorchConversion/Transforms/VerifyTosaLinalgBackendContract.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/VerifyTosaLinalgBackendContract.cpp
@@ -1,0 +1,112 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Complex/IR/Complex.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MLProgram/IR/MLProgram.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorDialect.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"
+#include "torch-mlir/Dialect/TorchConversion/Transforms/Passes.h"
+
+#include "mlir/IR/BuiltinOps.h"
+
+using namespace mlir;
+using namespace mlir::torch;
+using namespace mlir::torch::TorchConversion;
+using namespace TMTensor;
+
+namespace {
+class VerifyTosaLinalgBackendContractPass
+    : public VerifyTosaLinalgBackendContractBase<
+          VerifyTosaLinalgBackendContractPass> {
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    auto module = getOperation();
+    TypeConverter converter;
+    converter.addConversion([](RankedTensorType type) -> Type {
+      if (BaseMemRefType::isValidElementType(type.getElementType()))
+        return type;
+      return nullptr;
+    });
+    TypeConverter scalarConverter;
+    for (TypeConverter *c : {&converter, &scalarConverter}) {
+      c->addConversion([](FloatType type) { return type; });
+      c->addConversion([](IntegerType type) { return type; });
+      c->addConversion([](IndexType type) { return type; });
+      c->addConversion([](ComplexType type) { return type; });
+    }
+
+    auto opHasLegalTypes = [&](Operation *op) { return converter.isLegal(op); };
+    auto isLegalScalarOp = [&](Operation *op) {
+      // We recognize basic scalar ops by them having the trait "Elementwise",
+      // even though we don't expect them to operate on tensors.
+      return scalarConverter.isLegal(op) &&
+             op->hasTrait<OpTrait::Elementwise>();
+    };
+
+    ConversionTarget target(*context);
+
+    // Structural operations.
+    target.addDynamicallyLegalOp<ModuleOp, func::FuncOp, func::ReturnOp>(
+        opHasLegalTypes);
+
+    target.addDynamicallyLegalOp<GetNextSeedOp>(opHasLegalTypes);
+
+    // Basic scalar operations.
+    target.addDynamicallyLegalDialect<func::FuncDialect>(isLegalScalarOp);
+    target.addDynamicallyLegalDialect<math::MathDialect>(isLegalScalarOp);
+    target.addDynamicallyLegalDialect<arith::ArithDialect>(isLegalScalarOp);
+    target.addDynamicallyLegalDialect<complex::ComplexDialect>(isLegalScalarOp);
+
+    // Tensor operations should go through linalg and the tensor dialect.
+    target.addDynamicallyLegalDialect<linalg::LinalgDialect>(opHasLegalTypes);
+    target.addDynamicallyLegalDialect<sparse_tensor::SparseTensorDialect>(
+        opHasLegalTypes);
+    target.addDynamicallyLegalDialect<tensor::TensorDialect>(opHasLegalTypes);
+    target.addDynamicallyLegalDialect<tosa::TosaDialect>(opHasLegalTypes);
+    target.addDynamicallyLegalDialect<affine::AffineDialect>(opHasLegalTypes);
+    target.addDynamicallyLegalDialect<cf::ControlFlowDialect>(opHasLegalTypes);
+    target.addDynamicallyLegalDialect<TMTensorDialect>(opHasLegalTypes);
+    target.addDynamicallyLegalDialect<scf::SCFDialect>(opHasLegalTypes);
+    target.addDynamicallyLegalDialect<ml_program::MLProgramDialect>(
+        opHasLegalTypes);
+
+    // ConstantOp is used for tensors and for scalars.
+    target.addDynamicallyLegalOp<arith::ConstantOp>(opHasLegalTypes);
+    target.addDynamicallyLegalOp<complex::CreateOp>(opHasLegalTypes);
+
+    RewritePatternSet patterns(context);
+    if (failed(applyFullConversion(module, target, std::move(patterns)))) {
+      // We avoid `module.emitError()` so that mlir-print-op-on-diagnostics
+      // doesn't unnecessarily spew out the entire module.
+      emitError(module.getLoc())
+          << "Module does not conform to the linalg-on-tensors backend "
+             "contract. "
+             "See dialect conversion legality information above.";
+      return signalPassFailure();
+    }
+  }
+};
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::torch::TorchConversion::createVerifyTosaLinalgBackendContractPass() {
+  return std::make_unique<VerifyTosaLinalgBackendContractPass>();
+}

--- a/projects/pt1/e2e_testing/main.py
+++ b/projects/pt1/e2e_testing/main.py
@@ -85,6 +85,7 @@ def _get_argparse():
         "fx_importer",
         "fx_importer_stablehlo",
         "fx_importer_tosa",
+        "fx_importer_tosa_linalg",
     ]
     parser = argparse.ArgumentParser(description="Run torchscript e2e tests.")
     parser.add_argument(
@@ -105,6 +106,7 @@ Meaning of options:
 "fx_importer": run the model through the fx importer frontend and execute the graph using Linalg-on-Tensors.
 "fx_importer_stablehlo": run the model through the fx importer frontend and execute the graph using Stablehlo backend.
 "fx_importer_tosa": run the model through the fx importer frontend and execute the graph using the TOSA backend.
+"fx_importer_tosa_linalg": run the model through the fx importer frontend and execute the graph using the TOSA+Linalg backend.
 "onnx_tosa": Import ONNX to Torch via the torch-onnx-to-torch path and execute the graph using the TOSA backend.
 """,
     )
@@ -194,6 +196,10 @@ def main():
         config = FxImporterTestConfig(LinalgOnTensorsTosaBackend(), "tosa")
         xfail_set = FX_IMPORTER_TOSA_XFAIL_SET
         crashing_set = FX_IMPORTER_TOSA_CRASHING_SET
+    elif args.config == "fx_importer_tosa_linalg":
+        config = FxImporterTestConfig(LinalgOnTensorsTosaBackend(), "tosa_linalg")
+        xfail_set = FX_IMPORTER_XFAIL_SET
+        crashing_set = FX_IMPORTER_CRASHING_SET
     elif args.config == "torchdynamo":
         # TODO: Enanble runtime verification and extend crashing set.
         config = TorchDynamoTestConfig(

--- a/python/torch_mlir/compiler_utils.py
+++ b/python/torch_mlir/compiler_utils.py
@@ -158,6 +158,14 @@ class OutputType(Enum):
     # for end-users, but can be convenient for development or reporting bugs.
     RAW = "raw"
 
+    # The output type contains a mix of `tosa`, `linalg`-on-tensors ops, `scf`, and
+    # `arith` ops (and also `math` and `tm_tensor`). It can be thought of
+    # as taking the `TORCH` output type and lowering it so that tensor
+    # computations are done with `tosa` and `linalg`-on-tensors ops.
+    # `torch` ops are first lowered to `tosa` as much as possible.
+    # Remaining ops are then lowered to `linalg`-on-tensors.
+    TOSA_LINALG = "tosa-linalg"
+
     @staticmethod
     def get(spec: Union[str, "OutputType"]) -> "OutputType":
         """Gets an OutputType from allowed way to specify one.
@@ -209,6 +217,18 @@ def lower_mlir_module(verbose, output_type, module):
         if verbose:
             print("\n====================")
             print("LINALG Backend IR")
+            print(module)
+        return module
+
+    elif output_type == OutputType.TOSA_LINALG:
+        run_pipeline_with_repro_report(
+            module,
+            "builtin.module(torch-backend-to-tosa-linalg-backend-pipeline)",
+            "Lowering Torch Backend IR -> TOSA + Linalg Backend IR",
+        )
+        if verbose:
+            print("\n====================")
+            print("TOSA + Linalg Backend IR")
             print(module)
         return module
 

--- a/test/Conversion/TorchToTosa/torch-backend-to-tosa-backend-pipeline.mlir
+++ b/test/Conversion/TorchToTosa/torch-backend-to-tosa-backend-pipeline.mlir
@@ -136,3 +136,11 @@ func.func @torch.prim.TupleConstruct() {
   torch.prim.Print(%0) : !torch.tuple<int>
   return
 }
+
+// -----
+func.func @torch.aten.size.int(%arg0: !torch.vtensor<[4,2],f32>) -> !torch.int {
+    %c2 = torch.constant.int 2
+    // expected-error @below {{failed to legalize operation 'torch.aten.size.int' that was explicitly marked illegal}}
+    %0 = torch.aten.size.int %arg0, %c2 : !torch.vtensor<[4,2],f32>, !torch.int -> !torch.int
+    return %0 : !torch.int
+}

--- a/test/Conversion/TorchToTosa/torch-backend-to-tosa-linalg-backend-pipeline.mlir
+++ b/test/Conversion/TorchToTosa/torch-backend-to-tosa-linalg-backend-pipeline.mlir
@@ -1,7 +1,5 @@
 // RUN: torch-mlir-opt -pass-pipeline='builtin.module(torch-backend-to-tosa-linalg-backend-pipeline)' -split-input-file -verify-diagnostics %s | FileCheck %s
 
-// RUN: torch-mlir-opt -pass-pipeline='builtin.module(torch-backend-to-tosa-backend-pipeline)' -split-input-file -verify-diagnostics %s | FileCheck %s -check-prefix=CHECK-TOSA-BACKEND
-
 //-----
 
 // CHECK-LABEL:   func.func @torch.aten.size.int(
@@ -14,7 +12,6 @@
 // CHECK:           return %[[VAL_3]] : i64
 func.func @torch.aten.size.int(%arg0: !torch.vtensor<[4,2],f32>) -> !torch.int {
     %c2 = torch.constant.int 2
-    // CHECK-TOSA-BACKEND: expected-error @below {{failed to legalize operation 'torch.aten.size.int' that was explicitly marked illegal}}
     %0 = torch.aten.size.int %arg0, %c2 : !torch.vtensor<[4,2],f32>, !torch.int -> !torch.int
     return %0 : !torch.int
 }

--- a/test/Conversion/TorchToTosa/torch-backend-to-tosa-linalg-backend-pipeline.mlir
+++ b/test/Conversion/TorchToTosa/torch-backend-to-tosa-linalg-backend-pipeline.mlir
@@ -1,0 +1,20 @@
+// RUN: torch-mlir-opt -pass-pipeline='builtin.module(torch-backend-to-tosa-linalg-backend-pipeline)' -split-input-file -verify-diagnostics %s | FileCheck %s
+
+// RUN: torch-mlir-opt -pass-pipeline='builtin.module(torch-backend-to-tosa-backend-pipeline)' -split-input-file -verify-diagnostics %s | FileCheck %s -check-prefix=CHECK-TOSA-BACKEND
+
+//-----
+
+// CHECK-LABEL:   func.func @torch.aten.size.int(
+// CHECK-SAME:                                   %[[ARG0:.*]]: tensor<4x2xf32>) -> i64 {
+// CHECK:           %[[VAL_0:.*]] = arith.constant false
+// CHECK:           %[[VAL_1:.*]] = arith.constant 2 : index
+// CHECK:           cf.assert %[[VAL_0]], "dim must be smaller than inputRank"
+// CHECK:           %[[VAL_2:.*]] = tensor.dim %[[ARG0]], %[[VAL_1]] : tensor<4x2xf32>
+// CHECK:           %[[VAL_3:.*]] = arith.index_cast %[[VAL_2]] : index to i64
+// CHECK:           return %[[VAL_3]] : i64
+func.func @torch.aten.size.int(%arg0: !torch.vtensor<[4,2],f32>) -> !torch.int {
+    %c2 = torch.constant.int 2
+    // CHECK-TOSA-BACKEND: expected-error @below {{failed to legalize operation 'torch.aten.size.int' that was explicitly marked illegal}}
+    %0 = torch.aten.size.int %arg0, %c2 : !torch.vtensor<[4,2],f32>, !torch.int -> !torch.int
+    return %0 : !torch.int
+}

--- a/utils/bazel/torch-mlir-overlay/BUILD.bazel
+++ b/utils/bazel/torch-mlir-overlay/BUILD.bazel
@@ -553,6 +553,7 @@ cc_library(
         ":TorchMLIRTorchToTMTensor",
         ":TorchMLIRTorchToTensor",
         ":TorchMLIRTorchToTosa",
+        ":TorchMLIRTorchToTosaLinalg",
     ],
 )
 
@@ -581,6 +582,7 @@ cc_library(
         ":TorchMLIRTorchToTMTensor",
         ":TorchMLIRTorchToTensor",
         ":TorchMLIRTorchToTosa",
+        ":TorchMLIRTorchToTosaLinalg",
         "@llvm-project//mlir:ConversionPasses",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:LinalgDialect",
@@ -608,6 +610,20 @@ cc_library(
         "@llvm-project//mlir:Dialect",
         "@llvm-project//mlir:QuantOps",
         "@llvm-project//mlir:TosaDialect",
+    ],
+)
+
+cc_library(
+    name = "TorchMLIRTorchToTosaLinalg",
+    srcs = glob([
+        "lib/Conversion/*.h",
+        "lib/Conversion/TorchToTosaLinalg/*.cpp",
+    ]),
+    hdrs = glob(["include/torch-mlir/Conversion/TorchToTosaLinalg/*.h"]),
+    strip_include_prefix = "include",
+    deps = [
+        ":TorchMLIRTorchToTosa",
+        ":TorchMLIRTorchToLinalg",
     ],
 )
 


### PR DESCRIPTION
1. Run `tosa` pipeline before running `linalg_on_tensors` pipeline to keep as many ops in `tosa` as possible.
2. Bypass the `addIllegalOp` check for existing `tosa` pipeline by passing a pipeline configuration flag. This allows not erroring in the middle of the pipeline if some ops like `broadcast_to` cannot be converted to `tosa` from `torch` during the `tosa` pipeline. 
3. `VerifyTosaLinalgBackendContract` verifies that no unexpected op is present after the whole pipeline runs, otherwise it errors.
4. Added failures for some `tosa::ReshapeOp` creation when there's multiple dynamic dims being created by the `reshapeOp` which is not supported. These ops are eventually lowered during the `linalg_on_tensors` pipeline.