### PR TITLE
Bugfix to remove tm_tensor dialect as legal after tosa+linalg pass

### DIFF
--- a/lib/Dialect/TorchConversion/Transforms/VerifyTosaLinalgBackendContract.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/VerifyTosaLinalgBackendContract.cpp
@@ -83,7 +83,6 @@ class VerifyTosaLinalgBackendContractPass
     target.addDynamicallyLegalDialect<tosa::TosaDialect>(opHasLegalTypes);
     target.addDynamicallyLegalDialect<affine::AffineDialect>(opHasLegalTypes);
     target.addDynamicallyLegalDialect<cf::ControlFlowDialect>(opHasLegalTypes);
-    target.addDynamicallyLegalDialect<TMTensorDialect>(opHasLegalTypes);
     target.addDynamicallyLegalDialect<scf::SCFDialect>(opHasLegalTypes);
     target.addDynamicallyLegalDialect<ml_program::MLProgramDialect>(
         opHasLegalTypes);


### PR DESCRIPTION
We would consider `tm_tensor` as the legal dialect after the `torch-to-tosaLinalg` conversion. However, any dialect other than the MLIR core dialects should be illegal after `torch-to-tosaLinalg` pass. This change updates `VerifyTosaLinalgBackendContract to remove the `tm_tensor` dialect from the legal dialect list.

For the `hf_Roberta_base` model, without this change, `torch-to-tosaLinAlg` would succeed; now, it will fail with the error below, as expected. I am looking into enabling the `tm-tensor-to-loops` pass in a separate task. This pass has some issues when operands to the operations are of `tensor` type.

`
%230:2 = "tm_tensor.scan"(%225, %227, %229) <{dimension = 1 : i64, inclusive = true, operandSegmentSizes = array<i32: 1, 2>}> ({
^bb0(%arg2: i64, %arg3: i64):
  %1885 = "arith.addi"(%arg2, %arg3) <{overflowFlags = #arith.overflow<none>}> : (i64, i64) -> i64
  "tm_tensor.yield"(%1885) : (i64) -> ()
}) : (tensor<1x512xi64>, tensor<1x512xi64>, tensor<1xi64>) -> (tensor<1x512xi64>, tensor<1xi64>)
/local-ssd/hhanuman/25awork/Pytorch/modelConversion/pytorch-scripts/codegen/hf_Roberta_base.torch.mlir:1:1: error: Module does not conform to the linalg-on-tensors backend contract. See dialect conversion legality information above.
module {
`
@sahas3 , @rafaelubalmw 